### PR TITLE
Avoid throwing exception in .ku on trailing spaces

### DIFF
--- a/kitsu.py
+++ b/kitsu.py
@@ -260,7 +260,7 @@ def fetch_manga(query):
 @commands('ku')
 @example('.ku SleepingPanda')
 def ku(bot, trigger):
-    query = trigger.group(2) or None
+    query = trigger.group(3) or None
     bot.say(truncate_result(fetch_user(query)))
 
 


### PR DESCRIPTION
Kitsu usernames cannot contain whitespace, so using trigger group 3 will make sure the command only ever gets a valid username value. (Group 2 is the whole argument string, which isn't needed for this command. The alternative solution would be `trigger.group(2).strip()`, but that could then contain spaces and again make the passed-in username invalid.)